### PR TITLE
Use "cat.slug" as a key for each element in categories list

### DIFF
--- a/pages/categories/_single.vue
+++ b/pages/categories/_single.vue
@@ -17,7 +17,7 @@
         <div class="panel">
           <nuxt-link
             v-for="cat in allCats"
-            :key="cat"
+            :key="cat.slug"
             :to="`/categories/${cat.slug}`"
             :class="{
               'panel-block': true,


### PR DESCRIPTION
This fixes duplicate key error in single category component [issue #5]

The single category component lists all the categories in the sidebar. The used key for the v-for cicle, though, was the entire category object which is wrong. Replacing that with the category.slug value, which should be unique, fixes the error.