### PR TITLE
Short Intro Text in post grid

### DIFF
--- a/assets/scss/_typography.scss
+++ b/assets/scss/_typography.scss
@@ -1,0 +1,9 @@
+.excerpt {
+    font-weight: 500;
+    font-size: 18px;
+    color: black;
+}
+.date-wrapper {
+    font-weight: 600;
+    font-size: 15px;
+}

--- a/assets/scss/_typography.scss
+++ b/assets/scss/_typography.scss
@@ -1,7 +1,6 @@
 .excerpt {
     font-weight: 500;
     font-size: 18px;
-    color: black;
 }
 .date-wrapper {
     font-weight: 600;

--- a/assets/scss/styles.scss
+++ b/assets/scss/styles.scss
@@ -3,6 +3,7 @@
 @import "animations";
 @import "transitions";
 @import "util";
+@import "typography";
 // Import Bulma and Buefy styles
 @import "~bulma";
 @import "~buefy/src/scss/buefy";

--- a/cms/netlify/static/admin/config.yml
+++ b/cms/netlify/static/admin/config.yml
@@ -16,6 +16,7 @@ collections:
     fields: # The fields for each document, usually in front matter
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Subtitle", name: "subtitle", widget: "string"}
+      - {label: "Intro", name: "short", widget: "string"}
       - {label: "Category", name: "category", widget: "relation", collection: "categories", searchFields: "name", valueField: "name", multiple: true}
       - {label: "Author", name: "author", widget: "string", default: "Daniel Kelly"}
       - {label: "Publish Date", name: "date", widget: "datetime"}

--- a/components/cards/PostCard.vue
+++ b/components/cards/PostCard.vue
@@ -46,6 +46,10 @@ export default {
     author: {
       type: String,
       default: ''
+    },
+    short: {
+      type: String,
+      default: ''
     }
   },
   computed: {

--- a/components/cards/PostCard.vue
+++ b/components/cards/PostCard.vue
@@ -18,6 +18,10 @@
     <span v-if="date" class="date-wrapper">
       <strong>Published on:</strong> {{ datePretty }}
     </span>
+    <br />
+    <p class="excerpt">
+      {{ short }}
+    </p>
   </generic-card>
 </template>
 

--- a/components/grids/PostsGrid.vue
+++ b/components/grids/PostsGrid.vue
@@ -11,6 +11,7 @@
         :image="item.featureImage"
         :author="item.author"
         :date="item.date"
+        :short="item.short"
       />
     </template>
   </resource-grid>


### PR DESCRIPTION
- Added a short intro text / excerpt beneath the post cards. 
- Also added the capability to the netlify cms. 

![Screenshot_20200128_120423](https://user-images.githubusercontent.com/23221790/73258607-5e523f80-41c6-11ea-8fbc-93927f7baa22.png)

- if left empty, no intro / excerpt is shown. 