### PR TITLE
Use list for searchFields in Netlify CMS config

### DIFF
--- a/cms/netlify/static/admin/config.yml
+++ b/cms/netlify/static/admin/config.yml
@@ -16,7 +16,7 @@ collections:
     fields: # The fields for each document, usually in front matter
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Subtitle", name: "subtitle", widget: "string"}
-      - {label: "Category", name: "category", widget: "relation", collection: "categories", searchFields: "name", valueField: "name", multiple: true}
+      - {label: "Category", name: "category", widget: "relation", collection: "categories", searchFields: ["name"], valueField: "name", multiple: true}
       - {label: "Author", name: "author", widget: "string", default: "Daniel Kelly"}
       - {label: "Publish Date", name: "date", widget: "datetime"}
       - {label: "Featured Image", name: "featureImage", widget: "image"}


### PR DESCRIPTION
Hi, my /admin site broke recently, returning "Config Errors: 'searchFields' should be array".  Docs say the searchFields should be an array/list https://www.netlifycms.org/docs/widgets/#relation.  This bug: https://github.com/netlify/netlify-cms/issues/3787#issuecomment-631323687, although it's talking about displayFields not searchFields, suggests Netlify CMS is being more strict about this sort of thing now .  I tested and same problem also appears in a one-click "Deploy to Netlify" site from this repo's README.md.
