### PR TITLE
Upgraded Added GIF images support.

### DIFF
--- a/components/Markdown.vue
+++ b/components/Markdown.vue
@@ -37,22 +37,31 @@ export default {
       const images = html.match(/<img(.*?)>/g)
       if (images) {
         images.forEach((image) => {
-          // const generatedImage = require('~/assets')
           const origImage = image
             .match(/src="([^"]*)"/g)[0]
             .replace('src="', '')
             .replace('"', '')
           let replace = `src="${origImage}"`
-          if (origImage.startsWith('/')) {
-            const generatedImage = require(`~/assets${origImage}`)
-            replace = `src="${generatedImage.src}" srcset="${generatedImage.srcSet}"`
-          }
 
-          const optiImage = image
-            .replace('<img', '<opti-image')
-            .replace('>', '/>')
-            .replace(/src="([^"]*)"/g, replace)
-          html = html.replace(image, optiImage)
+          const generatedImage = require(`~/assets${origImage}`)
+          if (origImage.endsWith('.gif')) {
+            if (origImage.startsWith('/')) {
+              replace = `src="${generatedImage}"`
+            }
+
+            const gifImage = image.replace(/src="([^"]*)"/g, replace)
+            html = html.replace(image, gifImage)
+          } else {
+            if (origImage.startsWith('/')) {
+              replace = `src="${generatedImage.src}" srcset="${generatedImage.srcSet}"`
+            }
+
+            const optiImage = image
+              .replace('<img', '<opti-image')
+              .replace('>', '/>')
+              .replace(/src="([^"]*)"/g, replace)
+            html = html.replace(image, optiImage)
+          }
         })
       }
       return html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1931,16 +1931,6 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@babel/preset-env": {
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.5.tgz",
@@ -2301,6 +2291,329 @@
       "requires": {
         "postcss": "^7.0.14",
         "purgecss": "^1.3.0"
+      }
+    },
+    "@jimp/bmp": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.6.8.tgz",
+      "integrity": "sha512-uxVgSkI62uAzk5ZazYHEHBehow590WAkLKmDXLzkr/XP/Hv2Fx1T4DKwJ/15IY5ktq5VAhAUWGXTyd8KWFsx7w==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "bmp-js": "^0.1.0",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/core": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.6.8.tgz",
+      "integrity": "sha512-JOFqBBcSNiDiMZJFr6OJqC6viXj5NVBQISua0eacoYvo4YJtTajOIxC4MqWyUmGrDpRMZBR8QhSsIOwsFrdROA==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "any-base": "^1.1.0",
+        "buffer": "^5.2.0",
+        "core-js": "^2.5.7",
+        "exif-parser": "^0.1.12",
+        "file-type": "^9.0.0",
+        "load-bmfont": "^1.3.1",
+        "mkdirp": "0.5.1",
+        "phin": "^2.9.1",
+        "pixelmatch": "^4.0.2",
+        "tinycolor2": "^1.4.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
+    },
+    "@jimp/custom": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.6.8.tgz",
+      "integrity": "sha512-FrYlzZRVXP2vuVwd7Nc2dlK+iZk4g6IaT1Ib8Z6vU5Kkwlt83FJIPJ2UUFABf3bF5big0wkk8ZUihWxE4Nzdng==",
+      "dev": true,
+      "requires": {
+        "@jimp/core": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/gif": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.6.8.tgz",
+      "integrity": "sha512-yyOlujjQcgz9zkjM5ihZDEppn9d1brJ7jQHP5rAKmqep0G7FU1D0AKcV+Ql18RhuI/CgWs10wAVcrQpmLnu4Yw==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7",
+        "omggif": "^1.0.9"
+      }
+    },
+    "@jimp/jpeg": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.6.8.tgz",
+      "integrity": "sha512-rGtXbYpFXAn471qLpTGvhbBMNHJo5KiufN+vC5AWyufntmkt5f0Ox2Cx4ijuBMDtirZchxbMLtrfGjznS4L/ew==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7",
+        "jpeg-js": "^0.3.4"
+      }
+    },
+    "@jimp/plugin-blit": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.6.8.tgz",
+      "integrity": "sha512-7Tl6YpKTSpvwQbnGNhsfX2zyl3jRVVopd276Y2hF2zpDz9Bycow7NdfNU/4Nx1jaf96X6uWOtSVINcQ7rGd47w==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-blur": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.6.8.tgz",
+      "integrity": "sha512-NpZCMKxXHLDQsX9zPlWtpMA660DQStY6/z8ZetyxCDbqrLe9YCXpeR4MNhdJdABIiwTm1W5FyFF4kp81PHJx3Q==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-color": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.6.8.tgz",
+      "integrity": "sha512-jjFyU0zNmGOH2rjzHuOMU4kaia0oo82s/7UYfn5h7OUkmUZTd6Do3ZSK1PiXA7KR+s4B76/Omm6Doh/0SGb7BQ==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7",
+        "tinycolor2": "^1.4.1"
+      }
+    },
+    "@jimp/plugin-contain": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.6.8.tgz",
+      "integrity": "sha512-p/P2wCXhAzbmEgXvGsvmxLmbz45feF6VpR4m9suPSOr8PC/i/XvTklTqYEUidYYAft4vHgsYJdS74HKSMnH8lw==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-cover": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.6.8.tgz",
+      "integrity": "sha512-2PvWgk+PJfRsfWDI1G8Fpjrsu0ZlpNyZxO2+fqWlVo6y/y2gP4v08FqvbkcqSjNlOu2IDWIFXpgyU0sTINWZLg==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-crop": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.6.8.tgz",
+      "integrity": "sha512-CbrcpWE2xxPK1n/JoTXzhRUhP4mO07mTWaSavenCg664oQl/9XCtL+A0FekuNHzIvn4myEqvkiTwN7FsbunS/Q==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-displace": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.6.8.tgz",
+      "integrity": "sha512-RmV2bPxoPE6mrPxtYSPtHxm2cGwBQr5a2p+9gH6SPy+eUMrbGjbvjwKNfXWUYD0leML+Pt5XOmAS9pIROmuruQ==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-dither": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.6.8.tgz",
+      "integrity": "sha512-x6V/qjxe+xypjpQm7GbiMNqci1EW5UizrcebOhHr8AHijOEqHd2hjXh5f6QIGfrkTFelc4/jzq1UyCsYntqz9Q==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-flip": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.6.8.tgz",
+      "integrity": "sha512-4il6Da6G39s9MyWBEee4jztEOUGJ40E6OlPjkMrdpDNvge6hYEAB31BczTYBP/CEY74j4LDSoY5LbcU4kv06yA==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-gaussian": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.6.8.tgz",
+      "integrity": "sha512-pVOblmjv7stZjsqloi4YzHVwAPXKGdNaHPhp4KP4vj41qtc6Hxd9z/+VWGYRTunMFac84gUToe0UKIXd6GhoKw==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-invert": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.6.8.tgz",
+      "integrity": "sha512-11zuLiXDHr6tFv4U8aieXqNXQEKbDbSBG/h+X62gGTNFpyn8EVPpncHhOqrAFtZUaPibBqMFlNJ15SzwC7ExsQ==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-mask": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.6.8.tgz",
+      "integrity": "sha512-hZJ0OiKGJyv7hDSATwJDkunB1Ie80xJnONMgpUuUseteK45YeYNBOiZVUe8vum8QI1UwavgBzcvQ9u4fcgXc9g==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-normalize": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.6.8.tgz",
+      "integrity": "sha512-Q4oYhU+sSyTJI7pMZlg9/mYh68ujLfOxXzQGEXuw0sHGoGQs3B0Jw7jmzGa6pIS06Hup5hD2Zuh1ppvMdjJBfQ==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-print": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.6.8.tgz",
+      "integrity": "sha512-2aokejGn4Drv1FesnZGqh5KEq0FQtR0drlmtyZrBH+r9cx7hh0Qgf4D1BOTDEgXkfSSngjGRjKKRW/fwOrVXYw==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7",
+        "load-bmfont": "^1.4.0"
+      }
+    },
+    "@jimp/plugin-resize": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.6.8.tgz",
+      "integrity": "sha512-27nPh8L1YWsxtfmV/+Ub5dOTpXyC0HMF2cu52RQSCYxr+Lm1+23dJF70AF1poUbUe+FWXphwuUxQzjBJza9UoA==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-rotate": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.6.8.tgz",
+      "integrity": "sha512-GbjETvL05BDoLdszNUV4Y0yLkHf177MnqGqilA113LIvx9aD0FtUopGXYfRGVvmtTOTouoaGJUc+K6qngvKxww==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugin-scale": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.6.8.tgz",
+      "integrity": "sha512-GzIYWR/oCUK2jAwku23zt19V1ssaEU4pL0x2XsLNKuuJEU6DvEytJyTMXCE7OLG/MpDBQcQclJKHgiyQm5gIOQ==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7"
+      }
+    },
+    "@jimp/plugins": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.6.8.tgz",
+      "integrity": "sha512-fMcTI72Vn/Lz6JftezTURmyP5ml/xGMe0Ljx2KRJ85IWyP33vDmGIUuutFiBEbh2+y7lRT+aTSmjs0QGa/xTmQ==",
+      "dev": true,
+      "requires": {
+        "@jimp/plugin-blit": "^0.6.8",
+        "@jimp/plugin-blur": "^0.6.8",
+        "@jimp/plugin-color": "^0.6.8",
+        "@jimp/plugin-contain": "^0.6.8",
+        "@jimp/plugin-cover": "^0.6.8",
+        "@jimp/plugin-crop": "^0.6.8",
+        "@jimp/plugin-displace": "^0.6.8",
+        "@jimp/plugin-dither": "^0.6.8",
+        "@jimp/plugin-flip": "^0.6.8",
+        "@jimp/plugin-gaussian": "^0.6.8",
+        "@jimp/plugin-invert": "^0.6.8",
+        "@jimp/plugin-mask": "^0.6.8",
+        "@jimp/plugin-normalize": "^0.6.8",
+        "@jimp/plugin-print": "^0.6.8",
+        "@jimp/plugin-resize": "^0.6.8",
+        "@jimp/plugin-rotate": "^0.6.8",
+        "@jimp/plugin-scale": "^0.6.8",
+        "core-js": "^2.5.7",
+        "timm": "^1.6.1"
+      }
+    },
+    "@jimp/png": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.6.8.tgz",
+      "integrity": "sha512-JHHg/BZ7KDtHQrcG+a7fztw45rdf7okL/YwkN4qU5FH7Fcrp41nX5QnRviDtD9hN+GaNC7kvjvcqRAxW25qjew==",
+      "dev": true,
+      "requires": {
+        "@jimp/utils": "^0.6.8",
+        "core-js": "^2.5.7",
+        "pngjs": "^3.3.3"
+      }
+    },
+    "@jimp/tiff": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.6.8.tgz",
+      "integrity": "sha512-iWHbxd+0IKWdJyJ0HhoJCGYmtjPBOusz1z1HT/DnpePs/Lo3TO4d9ALXqYfUkyG74ZK5jULZ69KLtwuhuJz1bg==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.7",
+        "utif": "^2.0.1"
+      }
+    },
+    "@jimp/types": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.6.8.tgz",
+      "integrity": "sha512-vCZ/Cp2osy69VP21XOBACfHI5HeR60Rfd4Jidj4W73UL+HrFWOtyQiJ7hlToyu1vI5mR/NsUQpzyQvz56ADm5A==",
+      "dev": true,
+      "requires": {
+        "@jimp/bmp": "^0.6.8",
+        "@jimp/gif": "^0.6.8",
+        "@jimp/jpeg": "^0.6.8",
+        "@jimp/png": "^0.6.8",
+        "@jimp/tiff": "^0.6.8",
+        "core-js": "^2.5.7",
+        "timm": "^1.6.1"
+      }
+    },
+    "@jimp/utils": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.6.8.tgz",
+      "integrity": "sha512-7RDfxQ2C/rarNG9iso5vmnKQbcvlQjBIlF/p7/uYj72WeZgVCB+5t1fFBKJSU4WhniHX4jUMijK+wYGE3Y3bGw==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.7"
       }
     },
     "@nuxt/babel-preset-app": {
@@ -4497,13 +4810,21 @@
       }
     },
     "buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.0.tgz",
+      "integrity": "sha512-cd+5r1VLBwUqTrmnzW+D7ABkJUM6mr7uv1dv+6jRw4Rcl7tFIFHDqHPL98LhpGFn3dbAt3gtLxtrWp4m1kFrqg==",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+          "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+          "dev": true
+        }
       }
     },
     "buffer-equal": {
@@ -9463,9 +9784,9 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
       "dev": true
     },
     "is-generator-function": {
@@ -9723,10 +10044,31 @@
         }
       }
     },
+    "jimp": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.6.8.tgz",
+      "integrity": "sha512-F7emeG7Hp61IM8VFbNvWENLTuHe0ghizWPuP4JS9ujx2r5mCVYEd/zdaz6M2M42ZdN41blxPajLWl9FXo7Mr2Q==",
+      "dev": true,
+      "requires": {
+        "@jimp/custom": "^0.6.8",
+        "@jimp/plugins": "^0.6.8",
+        "@jimp/types": "^0.6.8",
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.13.3"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
     "jpeg-js": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.5.tgz",
-      "integrity": "sha512-hvaExqwmQDS8O9qnZAVDXGWU43Tbu1V0wMZmjROjT11jloSgGICZpscG+P6Nyi1BVAvyu2ARRx8qmEW30sxgdQ==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
+      "integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==",
       "dev": true
     },
     "jquery": {
@@ -9936,9 +10278,9 @@
       }
     },
     "load-bmfont": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.0.tgz",
-      "integrity": "sha512-kT63aTAlNhZARowaNYcY29Fn/QYkc52M3l6V1ifRcPewg2lvUZDAj7R6dXjOL9D0sict76op3T5+odumDSF81g==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
+      "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
       "dev": true,
       "requires": {
         "buffer-equal": "0.0.1",
@@ -11620,349 +11962,13 @@
       }
     },
     "nuxt-responsive-loader": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/nuxt-responsive-loader/-/nuxt-responsive-loader-1.0.3.tgz",
-      "integrity": "sha512-3W5sOLJ8BToFSW4l9WWz1DPEfeggfSD17MM5d0BI0yI4jCJKnREqHByWLGn9dmSwh3UCt1s/xd8mcdWXe4Nf+Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nuxt-responsive-loader/-/nuxt-responsive-loader-2.0.1.tgz",
+      "integrity": "sha512-apqWqad7qxCsD1hJE4P4PWM+G6OOgTXHnuxkk+/dmEyLMa1U2dteQaS6YjmY3FfvLSmQpTls5HqLNgAIGe4QUA==",
       "dev": true,
       "requires": {
         "jimp": "^0.6.0",
         "responsive-loader": "^1.2.0"
-      },
-      "dependencies": {
-        "@jimp/bmp": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.6.4.tgz",
-          "integrity": "sha512-dhKM7Cjw4XoOefx3/we2+vWyTP6hQPpM7mEsziGjtsrK2f/e3/+hhHbEsQNgO9BOA1FPJRXAOiYHts9IlMH1mg==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "bmp-js": "^0.1.0",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/core": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.6.4.tgz",
-          "integrity": "sha512-nyiAXI8/uU54fGO53KrRB8pdn1s+IODZ+rj0jG2owsNJlTlagFrsZAy8IVTUCOiiXjh9TbwFo7D5XMrmi4KUww==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "any-base": "^1.1.0",
-            "buffer": "^5.2.0",
-            "core-js": "^2.5.7",
-            "exif-parser": "^0.1.12",
-            "file-type": "^9.0.0",
-            "load-bmfont": "^1.3.1",
-            "mkdirp": "0.5.1",
-            "phin": "^2.9.1",
-            "pixelmatch": "^4.0.2",
-            "tinycolor2": "^1.4.1"
-          }
-        },
-        "@jimp/custom": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.6.4.tgz",
-          "integrity": "sha512-sdBHrBoVr1+PFx4dlUAgXvvu4dG0esQobhg7qhpSLRje1ScavIgE2iXdJKpycgzrqwAOL8vW4/E5w2/rONlaoQ==",
-          "dev": true,
-          "requires": {
-            "@jimp/core": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/gif": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.6.4.tgz",
-          "integrity": "sha512-14mLoyG0UrYJsGNRoXBFvSJdFtBD0BSBwQ1zCNeW+HpQqdl+Kh5E1Pz4nqT2KNylJe1jypyR51Q2yndgcfGVyg==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7",
-            "omggif": "^1.0.9"
-          }
-        },
-        "@jimp/jpeg": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.6.4.tgz",
-          "integrity": "sha512-NrFla9fZC/Bhw1Aa9vJ6cBOqpB5ylEPb9jD+yZ0fzcAw5HwILguS//oXv9EWLApIY1XsOMFFe0XWpY653rv8hw==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7",
-            "jpeg-js": "^0.3.4"
-          }
-        },
-        "@jimp/plugin-blit": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.6.4.tgz",
-          "integrity": "sha512-suVznd4XozkQIuECX0u8kMl+cAQpZN3WcbWXUcJaVxRi+VBvHIetG1Qs5qGLzuEg9627+kE7ppv0UgZ5mkE6lg==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-blur": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.6.4.tgz",
-          "integrity": "sha512-M2fDMYUUtEKVNnCJZk5J0KSMzzISobmWfnG88RdHXJCkOn98kdawQFwTsYOfJJfCM8jWfhIxwZLFhC/2lkTN2w==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-color": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.6.4.tgz",
-          "integrity": "sha512-6Nfr2l9KSb6zH2fij8G6fQOw85TTkyRaBlqMvDmsQp/I1IlaDbXzA2C2Eh9jkQYZQDPu61B1MkmlEhJp/TUx6Q==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7",
-            "tinycolor2": "^1.4.1"
-          }
-        },
-        "@jimp/plugin-contain": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.6.4.tgz",
-          "integrity": "sha512-qI1MxU1noS6NbEPu/bDDeP405aMviuIsfpOz8J3En8IwIwrJV22qt6QIHmF+eyng8CYgivwIPjEPzFzLR566Nw==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-cover": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.6.4.tgz",
-          "integrity": "sha512-z6eafPonj3LJY8cTEfRkXmOfCDi1+f0tbYaNvmiu+OrWJ3Ojw2hMt+BVVvJ8pKe1dWIFkCjxOjyjZWj1gEkaLw==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-crop": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.6.4.tgz",
-          "integrity": "sha512-w9TR+pn+GeWbznscGe2HRkPxInge0whAF3TLPWhPwBVjZChTT8dSDXsUpUlxQqvI4SfzuKp8z3/0SBqYDCzxxA==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-displace": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.6.4.tgz",
-          "integrity": "sha512-MEvtBXOAio/3iGJkKBrTtFs3Q38ez2Wy/wTD0Ruas+L8fjJR7l4mDgV+zjRr57CqB5mpY+L48VEoa2/gNXh9cg==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-dither": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.6.4.tgz",
-          "integrity": "sha512-w+AGLcIMUeJZ4CI0FvFomahgKLcW+ICsLidUNOqyLzceluPAfug4X7vDhQ41pNkzKg0M1+Q1j0aWV8bdyF+LhA==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-flip": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.6.4.tgz",
-          "integrity": "sha512-ukINMegMUM9KYjyDCiyYKYdSsbhNRLHDwOJN0xVRalmOKqNaZmjNbiMbaVxKlYt6sHW76RhSMOekw9f6GQB9tQ==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-gaussian": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.6.4.tgz",
-          "integrity": "sha512-C1P6ohzIddpNb7CX5X+ygbp+ow8Fpt64ZLoIgdjYPs/42HxKluvY62fVfMhY6m5zUGKIMbg0uYeAtz/9LRJPyw==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-invert": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.6.4.tgz",
-          "integrity": "sha512-sleGz1jXaNEsP/5Ayqw8oez/6KesWcyCqovIuK4Z4kDmMc2ncuhsXIJQXDWtIF4tTQVzNEgrxUDNA4bi9xpCUA==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-mask": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.6.4.tgz",
-          "integrity": "sha512-3D4FbRxnpO9nzwa6cF8AImgO1aVReYbfRRO4I4bku4/iZ+kuU3fBLV+SRhB4c7di3ejG5u+rGsIfaNc94iYYvw==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-normalize": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.6.4.tgz",
-          "integrity": "sha512-nOFMwOaVkOKArHkD/T6/1HKAPj3jlW6l0JduVDn1A5eIPCtlnyhlE9zdjgi5Q9IBR/gRjwW6tTzBKuJenS51kg==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-print": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.6.4.tgz",
-          "integrity": "sha512-3z5DLVCKg0NfZhHATEaYH/4XanIboPP1pOUoxIUeF++qOnGiGgH2giFJlRprHmx2l3E3DukR1v8pt54PGvfrFw==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7",
-            "load-bmfont": "^1.4.0"
-          }
-        },
-        "@jimp/plugin-resize": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.6.4.tgz",
-          "integrity": "sha512-fk2+KheUNClrOWj6aDNWj1r4byVQb6Qxy4aT1UHX5GXPHDA+nhlej7ghaYdzeWZYodeM3lpasYtByu1XE2qScQ==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-rotate": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.6.4.tgz",
-          "integrity": "sha512-44VgV5D4xQIYInJAVevdW9J3SOhGKyz0OEr2ciA8Q3ktonKx0O5Q1g2kbruiqxFSkK/u2CKPLeKXZzYCFrmJGQ==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugin-scale": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.6.4.tgz",
-          "integrity": "sha512-RAQRaDiCHmEz+A8QS5d/Z38EnlNsQizz3Mu3NsjA8uFtJsv1yMKWXZSQuzniofZw8tlMV6oI3VdM0eQVE07/5w==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "@jimp/plugins": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.6.4.tgz",
-          "integrity": "sha512-NpO/87CKnF4Q9r8gMl6w+jPKOM/C089qExkViD9cPvcFZEnyVOu7ucGzcMmTcabWOU62iQTOkRViPYr6XaK0LQ==",
-          "dev": true,
-          "requires": {
-            "@jimp/plugin-blit": "^0.6.4",
-            "@jimp/plugin-blur": "^0.6.4",
-            "@jimp/plugin-color": "^0.6.4",
-            "@jimp/plugin-contain": "^0.6.4",
-            "@jimp/plugin-cover": "^0.6.4",
-            "@jimp/plugin-crop": "^0.6.4",
-            "@jimp/plugin-displace": "^0.6.4",
-            "@jimp/plugin-dither": "^0.6.4",
-            "@jimp/plugin-flip": "^0.6.4",
-            "@jimp/plugin-gaussian": "^0.6.4",
-            "@jimp/plugin-invert": "^0.6.4",
-            "@jimp/plugin-mask": "^0.6.4",
-            "@jimp/plugin-normalize": "^0.6.4",
-            "@jimp/plugin-print": "^0.6.4",
-            "@jimp/plugin-resize": "^0.6.4",
-            "@jimp/plugin-rotate": "^0.6.4",
-            "@jimp/plugin-scale": "^0.6.4",
-            "core-js": "^2.5.7",
-            "timm": "^1.6.1"
-          }
-        },
-        "@jimp/png": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.6.4.tgz",
-          "integrity": "sha512-qv3oo6ll3XWVIToBwVC1wQX0MFKwpxbe2o+1ld9B4ZDavqvAHzalzcmTd/iyooI85CVDAcC3RRDo66oiizGZCQ==",
-          "dev": true,
-          "requires": {
-            "@jimp/utils": "^0.6.4",
-            "core-js": "^2.5.7",
-            "pngjs": "^3.3.3"
-          }
-        },
-        "@jimp/tiff": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.6.4.tgz",
-          "integrity": "sha512-8/vD4qleexmhPdppiu6fSstj/n/kGNTn8iIlf1emiqOuMN2PL9q5GOPDWU0xWdGNyJMMIDXJPgUFUkKfqXdg7w==",
-          "dev": true,
-          "requires": {
-            "core-js": "^2.5.7",
-            "utif": "^2.0.1"
-          }
-        },
-        "@jimp/types": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.6.4.tgz",
-          "integrity": "sha512-/EMbipQDg5U6DnBAgcSiydlMBRYoKhnaK7MJRImeTzhDJ6xfgNOF7lYq66o0kmaezKdG/cIwZ1CLecn2y3D8SQ==",
-          "dev": true,
-          "requires": {
-            "@jimp/bmp": "^0.6.4",
-            "@jimp/gif": "^0.6.4",
-            "@jimp/jpeg": "^0.6.4",
-            "@jimp/png": "^0.6.4",
-            "@jimp/tiff": "^0.6.4",
-            "core-js": "^2.5.7",
-            "timm": "^1.6.1"
-          }
-        },
-        "@jimp/utils": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.6.4.tgz",
-          "integrity": "sha512-EFQurCyEnZLSM2Q1BYDTUmsOJPSOYEQd18Fvq8bGo8hnBHoGLWLWWyNi2l4cYhtpKmIXyhvQqa6/WaEpKPzvqA==",
-          "dev": true,
-          "requires": {
-            "core-js": "^2.5.7"
-          }
-        },
-        "jimp": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.6.4.tgz",
-          "integrity": "sha512-WQVMoNhkcq/fgthZOWeMdIguCVPg+t4PDFfSxvbNcrECwl8eq3/Ou2whcFWWjyW45m43yAJEY2UT7acDKl6uSQ==",
-          "dev": true,
-          "requires": {
-            "@babel/polyfill": "^7.0.0",
-            "@jimp/custom": "^0.6.4",
-            "@jimp/plugins": "^0.6.4",
-            "@jimp/types": "^0.6.4",
-            "core-js": "^2.5.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        }
       }
     },
     "oauth-sign": {
@@ -12179,9 +12185,9 @@
       }
     },
     "omggif": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.9.tgz",
-      "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
       "dev": true
     },
     "on-finished": {
@@ -12432,14 +12438,10 @@
       }
     },
     "parse-headers": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
-      "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
-      "dev": true,
-      "requires": {
-        "for-each": "^0.3.3",
-        "string.prototype.trim": "^1.1.2"
-      }
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
+      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==",
+      "dev": true
     },
     "parse-json": {
       "version": "4.0.0",
@@ -16777,9 +16779,9 @@
       }
     },
     "timm": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/timm/-/timm-1.6.1.tgz",
-      "integrity": "sha512-hqDTYi/bWuDxL2i6T3v6nrvkAQ/1Bc060GSkVEQZp02zTSTB4CHSKsOkliequCftQaNRcjRqUZmpGWs5FfhrNg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
+      "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==",
       "dev": true
     },
     "timsort": {
@@ -16798,9 +16800,9 @@
       "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q=="
     },
     "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
       "dev": true
     },
     "tmp": {
@@ -18585,19 +18587,19 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
       "dev": true,
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "gray-matter-loader": "0.0.10",
     "node-sass": "^4.13.1",
     "nodemon": "^1.18.9",
-    "nuxt-responsive-loader": "^1.0.3",
+    "nuxt-responsive-loader": "^2.0.1",
     "prettier": "^1.16.4",
     "rimraf": "^2.6.3",
     "sass-loader": "^7.1.0",


### PR DESCRIPTION
## Description

GIF images aren't actually supported by the `nuxt-responsive-image` module. It causes a compilation issue. This PR adds support for GIF Images.

For more information, see the issue:
https://github.com/danielkellyio/awake-template/issues/48

## The Changes

The solution to this is to:

1. Upgrading to latest `nuxt-responsive-image` so that it won't cause build-time issues with GIFs.
2. Adjusted `Markdown.vue` so that it won't use `nuxt-responsive-image` to load gif images, and just use the default file loader.

## Proof that this works

See the below screenshot with GIF image loaded.

![image](https://user-images.githubusercontent.com/9282390/97524447-d02b1400-19f8-11eb-8780-5ea10ff48ce8.png)