### PR TITLE
Fix: Quotation marks after every table #60

### DIFF
--- a/components/Markdown.vue
+++ b/components/Markdown.vue
@@ -67,7 +67,7 @@ export default {
     },
     wrapTable(html) {
       html = html.replace(/<table/g, `<div class="table-wrapper"><table`)
-      html = html.replace(/<\/table>/g, `</table></div>"`)
+      html = html.replace(/<\/table>/g, `</table></div>`)
       return html
     }
   }

--- a/components/SiteSearch.vue
+++ b/components/SiteSearch.vue
@@ -43,7 +43,7 @@
       </ul>
     </span>
 
-    <label for="search-input">
+    <label v-if="query == ''" for="search-input">
       <font-awesome-icon
         icon="search"
         class="search-icon"


### PR DESCRIPTION
Corrections to the following issues have been made.

issue page
https://github.com/danielkellyio/awake-template/issues/60

In addition, I fixed the issue where the delete and magnifying glass marks were duplicated during article search.